### PR TITLE
Update LandingPage.jsx

### DIFF
--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -52,7 +52,7 @@ const LandingPage = () => {
   const repeatedStats = Array(10).fill(stats).flat();
 
   return (
-    <div className="h-screen overflow-y-scroll ">
+    <div>
       {/* Main Section */}
       <div className="flex flex-col gap-6 md:flex-row items-center justify-between p-8 md:p-16 bg-white/20">
         <div className="md:w-1/2">


### PR DESCRIPTION
fix scrolling error in home page . in homepage there will be two scrollbar and one of them is useless on scrolling the footer section also not visible properly need hard scrolling to display complete footer.

removing overflow-y scroll and h-screen class